### PR TITLE
Fixed index creation.

### DIFF
--- a/js/i.js
+++ b/js/i.js
@@ -13,7 +13,7 @@ var indexJson = [
 "companyPage":"{{entry.companyUrl}}",
 "languagesSupported":"{% for ls in entry.languagesSupported %}{{ls}},{% endfor %}",
 "language":"{{entry.language}}",
-"description":"{{entry.description}}",
+"description":"{{entry.description | strip_newlines}}",
 "tags":"{% for tag in entry.tags %}{{tag}},{% endfor %}"
 } {% unless forloop.last %},{% endunless %}
 {% endfor %}


### PR DESCRIPTION
 when the entry yml configuration file has a multiline description field, the index was not generated correctly. Adding a liquid filter **strip_newlines** it solves the problem.
